### PR TITLE
Added text-truncate to MenuItem's label

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -102,7 +102,7 @@ class MenuItem extends React.Component {
                     className={className + (this.props.isActive || this.state.active ? " active" : "") + (this.props.label ? " has-label" : "")}
                     onClick={event => this.onClick(event)}
                 >
-                    {icon} <span className="blue-app-sidebar-label">{this.props.label}</span>
+                    {icon} <span className="blue-app-sidebar-label text-truncate">{this.props.label}</span>
                     {this.props.children &&
                         <Caret
                             open={this.state.showDropdown}


### PR DESCRIPTION
I added `text-truncate` to the MenuItem's label. I did this it because when some text's in the Sidebar is to long the MenuItem's label will be some overlapping or it will be showing kind of weird.
For reference:
https://getbootstrap.com/docs/5.0/helpers/text-truncation/