### PR TITLE
Fixed Tooltips CSS

### DIFF
--- a/dist/styles/_tooltips.scss
+++ b/dist/styles/_tooltips.scss
@@ -72,7 +72,7 @@
     }
 }
 
-[data-tooltip][class^="blue-tooltip-up"] {
+[data-tooltip][class*="blue-tooltip-up"] {
     &::before {
         bottom: 100%;
         border-bottom-width: 0;
@@ -88,7 +88,7 @@
     }
 }
 
-[data-tooltip][class^="blue-tooltip-down"] {
+[data-tooltip][class*="blue-tooltip-down"] {
     &::before {
         top: 100%;
         border-top-width: 0;
@@ -156,8 +156,8 @@
 }
 
 // FX: do the thing
-[data-tooltip][class^="blue-tooltip-up"]:hover,
-[data-tooltip][class^="blue-tooltip-down"]:hover {
+[data-tooltip][class*="blue-tooltip-up"]:hover,
+[data-tooltip][class*="blue-tooltip-down"]:hover {
     &::before,
     &::after {
         animation: tips-vert 150ms cubic-bezier(0.5, 0, 0.6, 1.3) 1ms forwards;


### PR DESCRIPTION
`blue-tooltip-up` & `blue-tooltip-down` didn't worked when using it inside the `className` e.g. as second Paramter e.g. `<div className="d-block blue-tooltip-up" data-tooltip="test"></div>` = doesn't work. It only worked when those where as first Parameter like this: `<div className="blue-tooltip-up d-block" data-tooltip="test"></div>` = is working. 

I changed the CSS now so that it will work anywhere. The position of the CSS-Class is now not that important.

This Pull Request belongs to https://github.com/bruegmann/florence/pull/850