### PR TITLE
FLOR-725 RemoveEventListener 

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -184,11 +184,9 @@ export default class Grid extends Component<GridProps, GridState> {
         ) {
             this.setState({ blockRouting: this.props.blockRouting })
         }
-
-        this.removeDuplicatedEventListeners(this.eventListeners)
         this.eventListeners.forEach((eventListener) => {
             if (eventListener[0] === "componentDidUpdate") {
-                eventListener[2](prevProps, prevState)
+                eventListener[1](prevProps, prevState)
             }
 
             if (eventListener[0] === "pageDidShowAgain") {
@@ -294,18 +292,23 @@ export default class Grid extends Component<GridProps, GridState> {
         }
     }
 
-    addEventListener(param1: any, param2: any, param3: any) {
-        this.eventListeners.push([param1, param2, param3])
+    addEventListener(param1: any, param2: any, param3: any, listenerId: string) {
+        this.eventListeners.push([param1, param2, param3, listenerId])
+
+        // This removes all duplicates
+        let hashMap: any = {}
+        this.eventListeners.forEach((arr: any) => hashMap[arr.join("|")] = arr)
+        this.eventListeners = Object.keys(hashMap).map((k) => hashMap[k])
     }
 
-    removeEventListener(type: string, listener: any) {
+    removeEventListener(type: string, listenerId: string) {
         this.eventListeners = this.eventListeners.filter((param: any[]) => {
             if (param[0] !== type) {
                 return param
-            } else if (param[0] === type) {
-                if (param[2].toString().replace("\\n/g", "").replace(" ", "") !== listener.toString().replace("\\n/g", "").replace(" ", "")) {
-                    return param
-                }
+            } else if (param[0] === type && type !== "componentDidUpdate" && param[3] !== listenerId) {
+                return param
+            } else if (param[0] === type && param[0] === "componentDidUpdate" && param[2] !== listenerId) {
+                return param
             }
         })
     }
@@ -314,7 +317,6 @@ export default class Grid extends Component<GridProps, GridState> {
         let hashMap: any = {}
 
         eventListeners.forEach((arr: any) => hashMap[arr.join("|")] = arr)
-
         this.eventListeners = Object.keys(hashMap).map((k) => hashMap[k])
     }
 

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -185,9 +185,10 @@ export default class Grid extends Component<GridProps, GridState> {
             this.setState({ blockRouting: this.props.blockRouting })
         }
 
+        this.removeDuplicatedEventListeners(this.eventListeners)
         this.eventListeners.forEach((eventListener) => {
             if (eventListener[0] === "componentDidUpdate") {
-                eventListener[1](prevProps, prevState)
+                eventListener[2](prevProps, prevState)
             }
 
             if (eventListener[0] === "pageDidShowAgain") {
@@ -301,16 +302,20 @@ export default class Grid extends Component<GridProps, GridState> {
         this.eventListeners = this.eventListeners.filter((param: any[]) => {
             if (param[0] !== type) {
                 return param
-            } else if (param[0] === type && type !== "componentDidUpdate") {
+            } else if (param[0] === type) {
                 if (param[2].toString().replace("\\n/g", "").replace(" ", "") !== listener.toString().replace("\\n/g", "").replace(" ", "")) {
-                    return param
-                }
-            } else if (param[0] === "componentDidUpdate") {
-                if (param[1].toString().replace("\\n/g", "").replace(" ", "") !== listener.toString().replace("\\n/g", "").replace(" ", "")) {
                     return param
                 }
             }
         })
+    }
+
+    removeDuplicatedEventListeners(eventListeners: any) {
+        let hashMap: any = {}
+
+        eventListeners.forEach((arr: any) => hashMap[arr.join("|")] = arr)
+
+        this.eventListeners = Object.keys(hashMap).map((k) => hashMap[k])
     }
 
     render() {

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -89,17 +89,23 @@ export interface GridState {
 
 /**
  * The main component. As soon this component is mounted, it is globally available under `window.blueGridRef`.
- * Also you can append your own event listeners with `blueGridRef.addEventListener(eventName, (prevProps, prevState) => { })`
- * and remove it with `blueGridRef.removeEventListener(eventName, listener)`.
+ * You can also append your own event listeners.
  *
- * Allowed event listeners:
+ * Allowed events:
  *
  * * **componentDidUpdate** - Component was updated.
- *   Example: `blueGridRef.addEventListener("componentDidUpdate", (prevProps, prevState) => { })`
+ *   Example: `window.blueGridRef.addEventListener("componentDidUpdate", (prevProps, prevState) => { })`
  * * **pageDidShowAgain** - Page appeared again with the same old state. In the callback function you can reinitialize things.
- *   Example: `blueGridRef.addEventListener("pageDidShowAgain", "home", (prevProps, prevState) => { })`
+ *   Example: `window.blueGridRef.addEventListener("pageDidShowAgain", "home", (prevProps, prevState) => { })`
  * * **pageDidHide** - This page disappeared and another page appears instead.
- *   Example: `blueGridRef.addEventListener("pageDidHide", "home", (prevProps, prevState) => { })`
+ *   Example: `window.blueGridRef.addEventListener("pageDidHide", "home", (prevProps, prevState) => { })`
+ * 
+ * Method to add event listeners:
+ * * `window.blueGridRef.`**addEventListener**`(eventName: string, param2: any, param3: any, listenerId?: string)`
+ * 
+ * Methods to remove event listeners:
+ * * `window.blueGridRef.`**removeEventListener**`(eventName: string, listenerId: string)`
+ * * `window.blueGridRef.`**removeDuplicatedEventListeners**`()` - Will automatically be called when running `addEventListener`
  */
 export default class Grid extends Component<GridProps, GridState> {
     defaultMatch: string[]
@@ -292,7 +298,7 @@ export default class Grid extends Component<GridProps, GridState> {
         }
     }
 
-    addEventListener(param1: any, param2: any, param3: any, listenerId: string) {
+    addEventListener(param1: any, param2: any, param3: any, listenerId?: string) {
         this.eventListeners.push([param1, param2, param3, listenerId])
         this.removeDuplicatedEventListeners()
     }

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -301,8 +301,12 @@ export default class Grid extends Component<GridProps, GridState> {
         this.eventListeners = this.eventListeners.filter((param: any[]) => {
             if (param[0] !== type) {
                 return param
-            } else if (param[0] === type) {
+            } else if (param[0] === type && type !== "componentDidUpdate") {
                 if (param[2].toString().replace("\\n/g", "").replace(" ", "") !== listener.toString().replace("\\n/g", "").replace(" ", "")) {
+                    return param
+                }
+            } else if (param[0] === "componentDidUpdate") {
+                if (param[1].toString().replace("\\n/g", "").replace(" ", "") !== listener.toString().replace("\\n/g", "").replace(" ", "")) {
                     return param
                 }
             }

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -294,11 +294,7 @@ export default class Grid extends Component<GridProps, GridState> {
 
     addEventListener(param1: any, param2: any, param3: any, listenerId: string) {
         this.eventListeners.push([param1, param2, param3, listenerId])
-
-        // This removes all duplicates
-        let hashMap: any = {}
-        this.eventListeners.forEach((arr: any) => hashMap[arr.join("|")] = arr)
-        this.eventListeners = Object.keys(hashMap).map((k) => hashMap[k])
+        this.removeDuplicatedEventListeners(this.eventListeners)
     }
 
     removeEventListener(type: string, listenerId: string) {
@@ -316,7 +312,13 @@ export default class Grid extends Component<GridProps, GridState> {
     removeDuplicatedEventListeners(eventListeners: any) {
         let hashMap: any = {}
 
-        eventListeners.forEach((arr: any) => hashMap[arr.join("|")] = arr)
+        eventListeners.forEach((arr: any) => {
+            if (arr[0] !== "componentDidUpdate") {
+                hashMap[`${arr[0]}|${arr[3]}`] = arr
+            } else {
+                hashMap[`${arr[0]}|${arr[2]}`] = arr
+            }
+        })
         this.eventListeners = Object.keys(hashMap).map((k) => hashMap[k])
     }
 

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -298,7 +298,15 @@ export default class Grid extends Component<GridProps, GridState> {
     }
 
     removeEventListener(type: string, listener: any) {
-        this.eventListeners = this.eventListeners.filter((param: any[]) => param[0] !== type && param[2].toString() !== listener.toString())
+        this.eventListeners = this.eventListeners.filter((param: any[]) => {
+            if (param[0] !== type) {
+                return param
+            } else if (param[0] === type) {
+                if (param[2].toString().replace("\\n/g", "").replace(" ", "") !== listener.toString().replace("\\n/g", "").replace(" ", "")) {
+                    return param
+                }
+            }
+        })
     }
 
     render() {

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -294,32 +294,25 @@ export default class Grid extends Component<GridProps, GridState> {
 
     addEventListener(param1: any, param2: any, param3: any, listenerId: string) {
         this.eventListeners.push([param1, param2, param3, listenerId])
-        this.removeDuplicatedEventListeners(this.eventListeners)
+        this.removeDuplicatedEventListeners()
     }
 
     removeEventListener(type: string, listenerId: string) {
         this.eventListeners = this.eventListeners.filter((param: any[]) => {
             if (param[0] !== type) {
                 return param
-            } else if (param[0] === type && type !== "componentDidUpdate" && param[3] !== listenerId) {
-                return param
-            } else if (param[0] === type && param[0] === "componentDidUpdate" && param[2] !== listenerId) {
+            } else if (param[0] === type && param[3] !== listenerId) {
                 return param
             }
         })
     }
 
-    removeDuplicatedEventListeners(eventListeners: any) {
-        let hashMap: any = {}
-
-        eventListeners.forEach((arr: any) => {
-            if (arr[0] !== "componentDidUpdate") {
-                hashMap[`${arr[0]}|${arr[3]}`] = arr
-            } else {
-                hashMap[`${arr[0]}|${arr[2]}`] = arr
-            }
-        })
-        this.eventListeners = Object.keys(hashMap).map((k) => hashMap[k])
+    removeDuplicatedEventListeners() {
+        this.eventListeners = this.eventListeners.filter((value, index, self) =>
+            index === self.findIndex((t) => (
+                t[3] === value[3] && t[0] === value[0]
+            ))
+        )
     }
 
     render() {


### PR DESCRIPTION
## Jira-Task
https://jira.patorg.de/browse/FLOR-725

We came to an conclusion that an unique  listenerId should be set when  adding an EventListener. This will give us an easyier way to remove the duplicates and to remove the right EventListener when using `removeEventListener`.

Check if everything works fine like it should be.

Relates to https://github.com/bruegmann/blue-react/issues/92 