### PR TITLE
Set Style and Disabled for MenuItem

### DIFF
--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -124,6 +124,14 @@ export interface MenuItemProps {
     draggable?: boolean
 
     "data-tooltip"?: string
+    /**
+     * Specifies whether an element is disabled or not.
+     */
+    disabled?: boolean
+    /**
+     * Specifies style of an element.
+     */
+    style?: React.CSSProperties
 }
 
 /**
@@ -234,7 +242,9 @@ export default function MenuItem(props: MenuItemProps) {
                     onDragLeave: props.onDragLeave,
                     onDrop: props.onDrop,
                     draggable: props.draggable,
-                    "data-tooltip": props["data-tooltip"]
+                    "data-tooltip": props["data-tooltip"],
+                    disabled: props.disabled,
+                    style: props.style
                 },
                 <>
                     <span

--- a/src/docs/components/DemoApp.tsx
+++ b/src/docs/components/DemoApp.tsx
@@ -237,6 +237,14 @@ export default function DemoApp() {
                                         onClick={toggleEdit}
                                         isActive={edit}
                                     />
+                                    <MenuItem
+                                        icon={<Pencil className="bi" />}
+                                        iconForActive={<PencilFill className="bi" />}
+                                        label="Disabled Button with Tooltip"
+                                        title="This is a Tooltip!"
+                                        disabled
+                                        style={{ pointerEvents: "auto" }}
+                                    />
                                 </ActionMenu>
                             </Header>
                             <Body containerClass="container">


### PR DESCRIPTION
https://jira.patorg.de/browse/FLOR-1131

Set Style and Disabled Properties for MenuItem Component. So it's possible to disable a MenuItem and use CSS-Properties for e.g. showing the tooltip.